### PR TITLE
rule: more missing translation rules

### DIFF
--- a/rules/ux.py
+++ b/rules/ux.py
@@ -29,3 +29,20 @@ msgprint(_("Helpful message"))
 
 # ok: frappe-missing-translate-function-python
 frappe.throw(_("Error occured"))
+
+not_translated = "abc"
+
+# ruleid: frappe-missing-translate-function-python
+frappe.throw("Some Text" + not_translated + "More text")
+
+# ok: frappe-missing-translate-function-python
+frappe.throw(_("Some Text") + not_translated)
+
+# ok: frappe-missing-translate-function-python
+frappe.throw(_("Some Text") + not_translated, title=_("None"))
+
+# ruleid: frappe-missing-translate-function-python
+frappe.throw(_("Some Text"), title="Warning")
+
+# ok: frappe-missing-translate-function-python
+frappe.throw(_("Some Text"), title=_("Warning"))

--- a/rules/ux.yml
+++ b/rules/ux.yml
@@ -7,6 +7,18 @@ rules:
   - patterns:
       - pattern: frappe.throw("...", ...)
       - pattern-not: frappe.throw(_("..."), ...)
+  - patterns:
+      - pattern: frappe.throw("..." + ..., ...)
+      - pattern-not: frappe.throw(_("...") + ..., ...)
+  - patterns:
+      - pattern: frappe.msgprint("..." + ..., ...)
+      - pattern-not: frappe.msgprint(_("...") + ..., ...)
+  - patterns:
+      - pattern: frappe.throw(..., title="...")
+      - pattern-not: frappe.throw(..., title=_("..."))
+  - patterns:
+      - pattern: frappe.msgprint(..., title="...")
+      - pattern-not: frappe.msgprint(..., title=_("..."))
   message: |
       All user facing text must be wrapped in translate function. Please refer to translation documentation. https://frappeframework.com/docs/user/en/guides/basics/translations
   languages: [python]


### PR DESCRIPTION
We don't catch:

1. plain strings passed to msgprint/throw when it's concatenated. 
2. plain string titles

identified here: https://github.com/frappe/erpnext/pull/30238 