### PR TITLE
rule: basic DB multitenancy error with DB calls

### DIFF
--- a/rules/frappe_correctness.py
+++ b/rules/frappe_correctness.py
@@ -2,6 +2,14 @@ import frappe
 from frappe import _
 
 from frappe.model.document import Document
+from frappe.utils import cint
+
+
+# ruleid: frappe-breaks-multitenancy
+variable = frappe.db.get_value("ABC", "x", "y")
+
+# ruleid: frappe-breaks-multitenancy
+precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
 
 
 # ruleid: frappe-modifying-but-not-comitting
@@ -9,6 +17,22 @@ def on_submit(self):
 	if self.value_of_goods == 0:
 		frappe.throw(_('Value of goods cannot be 0'))
 	self.status = 'Submitted'
+
+	# ok: frappe-breaks-multitenancy
+	variable = frappe.db.get_value("ABC", "x", "y")
+
+
+class DocTyper(Document):
+	# ruleid: frappe-breaks-multitenancy
+	variable = frappe.db.get_value("ABC", "x", "y")
+
+	def validate(self):
+		# ok: frappe-breaks-multitenancy
+		variable = frappe.db.get_value("ABC", "x", "y")
+
+		# ok: frappe-breaks-multitenancy
+		self.attr = frappe.db.get_value("ABC", "x", "y")
+
 
 
 # ok: frappe-modifying-but-not-comitting

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -1,6 +1,21 @@
 # This file specifies rules for correctness according to how frappe doctype data model works.
 
 rules:
+- id: frappe-breaks-multitenancy
+  patterns:
+    - pattern: |
+        $VAR = <... frappe.db.$METHOD(...) ...>
+    - pattern-not-inside: |
+        def $FUNCTION(...):
+          ...
+  paths:
+    exclude:
+      - "**/test_*.py"
+  message: |
+    $VAR global variable does not respect database multitenancy, consider wrapping it in function or method call.
+  languages: [python]
+  severity: ERROR
+
 - id: frappe-modifying-but-not-comitting
   patterns:
     - pattern: |


### PR DESCRIPTION
Block use of DB methods on global variables. 

To prevent issues like:

https://github.com/frappe/erpnext/pull/30301
https://github.com/frappe/erpnext/pull/29942 


Added more thread locals and indirect DB reads via https://github.com/frappe/semgrep-rules/commit/bba70b39b20a0040e756e1d2bc317cb9b020d322 

