### PR TITLE
rule: Block setting translated strings as globals

### DIFF
--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -17,6 +17,7 @@ rules:
       - pattern: $VAR = <... frappe.conf ...>
       - pattern: $VAR = <... frappe.flags ...>
       - pattern: $VAR = <... frappe.lang ...>
+      - pattern: $VAR = <... frappe._ ...>
     - pattern-not-inside: |
         def $FUNCTION(...):
           ...

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -17,7 +17,7 @@ rules:
       - pattern: $VAR = <... frappe.conf ...>
       - pattern: $VAR = <... frappe.flags ...>
       - pattern: $VAR = <... frappe.lang ...>
-      - pattern: $VAR = <... frappe._ ...>
+      - pattern: $VAR = <... frappe._(...) ...>
     - pattern-not-inside: |
         def $FUNCTION(...):
           ...


### PR DESCRIPTION
Ref: https://github.com/frappe/frappe/pull/17089