### PR TITLE
rule: db.get_value type issue for singles

### DIFF
--- a/rules/frappe_correctness.py
+++ b/rules/frappe_correctness.py
@@ -128,3 +128,13 @@ frappe.local.flags = {}
 def replace_request():
 	# ruleid: frappe-overriding-local-proxies
 	frappe.request = {}
+
+
+def testing_something(self):
+	# ruleid: frappe-single-value-type-safety
+    duration = frappe.db.get_value("System Settings", None, "duration") or 24
+
+
+def testing_something(self):
+	# ok: frappe-single-value-type-safety
+    duration = frappe.db.get_single_value("System Settings", "duration") or 24

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -199,7 +199,7 @@ rules:
   message: |
     The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
   languages: [python]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-overriding-local-proxies
   patterns:

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -211,3 +211,14 @@ rules:
     frappe.$ATTR is a local proxy, assigning it to another object will remove the proxying and replace it with another object. Use frappe.local.$ATTR instead.
   languages: [python]
   severity: ERROR
+
+
+- id: frappe-single-value-type-safety
+  patterns:
+    - pattern-either:
+      - pattern: frappe.db.get_value($DOCTYPE, $DOCTYPE, ...)
+      - pattern: frappe.db.get_value($DOCTYPE, None, ...)
+  message: |
+    If $DOCTYPE is a single doctype then using `frappe.db.get_value` is discouraged for fetching value from single doctypes. frappe.db.get_value for single doctype is not type safe, use `frappe.db.get_single_value` instead.
+  languages: [python]
+  severity: ERROR

--- a/rules/translate.yml
+++ b/rules/translate.yml
@@ -7,7 +7,7 @@ rules:
     Empty string is useless for translation.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [python, javascript, json]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-translation-trailing-spaces
   pattern-either:
@@ -17,7 +17,7 @@ rules:
     Trailing or leading whitespace not allowed in translate strings.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [python, javascript, json]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-translation-python-formatting
   pattern-either:
@@ -28,7 +28,7 @@ rules:
     Only positional formatters are allowed and formatting should not be done before translating.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [python]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-translation-js-formatting
   patterns:
@@ -38,7 +38,7 @@ rules:
     Template strings are not allowed for text formatting.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [javascript, json]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-translation-python-splitting
   pattern-either:
@@ -49,7 +49,7 @@ rules:
     Do not split strings inside translate function. Do not concatenate using translate functions.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [python]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-translation-js-splitting
   pattern-either:
@@ -60,4 +60,4 @@ rules:
     Do not split strings inside translate function. Do not concatenate using translate functions.
     Please refer: https://frappeframework.com/docs/user/en/translations
   languages: [javascript, json]
-  severity: ERROR
+  severity: WARNING

--- a/rules/ux.yml
+++ b/rules/ux.yml
@@ -22,7 +22,7 @@ rules:
   message: |
       All user facing text must be wrapped in translate function. Please refer to translation documentation. https://frappeframework.com/docs/user/en/guides/basics/translations
   languages: [python]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-missing-translate-function-js
   pattern-either:
@@ -42,7 +42,7 @@ rules:
   message: |
       All user facing text must be wrapped in translate function. Please refer to translation documentation. https://frappeframework.com/docs/user/en/guides/basics/translations
   languages: [javascript]
-  severity: ERROR
+  severity: WARNING
 
 - id: frappe-missing-translation-button-text
   pattern-either:
@@ -54,4 +54,4 @@ rules:
   message: |
       All user facing button text must be wrapped in translate function. Please refer to translation documentation. https://frappeframework.com/docs/user/en/guides/basics/translations
   languages: [javascript]
-  severity: ERROR
+  severity: WARNING


### PR DESCRIPTION
`db.get_value("Single doctype", ...)` always returns a string. This is unexpected behavior that most people aren't aware of. 