### PR TITLE
rule: after_save hook doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
 	semgrep --validate --config=$$PWD/rules $$PWD
-	semgrep --test --strict --test-ignore-todo --quiet $$PWD
+	semgrep --test --strict --test-ignore-todo $$PWD

--- a/rules/frappe_correctness.py
+++ b/rules/frappe_correctness.py
@@ -138,3 +138,17 @@ def testing_something(self):
 def testing_something(self):
 	# ok: frappe-single-value-type-safety
     duration = frappe.db.get_single_value("System Settings", "duration") or 24
+
+
+# ruleid: frappe-after-save-controller-hook
+class DoctypeNew(Document):
+	def before_save(self):
+		self.good_method()
+
+	def after_save(self):
+		self.bad_method()
+
+# ok: frappe-after-save-controller-hook
+class DoctypeNew(Document):
+	def before_save(self):
+		self.good_method()

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -232,6 +232,3 @@ rules:
     `after_save` is not a valid DocType controller hook. Please have a look at the hooks available: https://frappeframework.com/docs/v13/user/en/basics/doctypes/controllers#controller-hooks
   languages: [python]
   severity: ERROR
-  paths:
-    include:
-      - "*/**/doctype/*"

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -222,3 +222,16 @@ rules:
     If $DOCTYPE is a single doctype then using `frappe.db.get_value` is discouraged for fetching value from single doctypes. frappe.db.get_value for single doctype is not type safe, use `frappe.db.get_single_value` instead.
   languages: [python]
   severity: ERROR
+
+- id: frappe-after-save-controller-hook
+  pattern: |
+    class $DOCTYPE($SOMEBASECLASS, ...):
+      def after_save(self):
+        ...
+  message: |
+    `after_save` is not a valid DocType controller hook. Please have a look at the hooks available: https://frappeframework.com/docs/v13/user/en/basics/doctypes/controllers#controller-hooks
+  languages: [python]
+  severity: ERROR
+  paths:
+    include:
+      - "*/**/doctype/*"


### PR DESCRIPTION
This pr adds semgrep rule for after_save controller hook (which doesn't exist).