### PR TITLE
chore: remove db.sql rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Rules
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: test-rules
-      uses: returntocorp/semgrep-rules-test-action@master
+      run: |
+        pip install semgrep
+        make test

--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -217,19 +217,6 @@ rules:
   languages: [python]
   severity: WARNING
 
-- id: frappe-using-db-sql
-  pattern-either:
-    - pattern: frappe.db.sql(...)
-    - pattern: frappe.db.sql_ddl(...)
-    - pattern: frappe.db.sql_list(...)
-  paths:
-    exclude:
-      - "test_*.py"
-  message: |
-    The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
-  languages: [python]
-  severity: WARNING
-
 - id: frappe-overriding-local-proxies
   patterns:
     - pattern: frappe.$ATTR = ...


### PR DESCRIPTION
Maturity is realizing raw queries have their place in codebase :smile: 

Almost all of the firings of this rule have been invalid, which indirectly leads people to ignore semgrep in general.