### PR TITLE
fix: update comment syntax for nosemgrep in transaction manual commit warning

### DIFF
--- a/rules/frappe_correctness.yml
+++ b/rules/frappe_correctness.yml
@@ -209,7 +209,7 @@ rules:
         except ...:
           ...
   message: |
-    Manually commiting a transaction is highly discouraged. Read about the transaction model implemented by Frappe Framework before adding manual commits: https://frappeframework.com/docs/user/en/api/database#database-transaction-model If you think manual commit is required then add a comment explaining why and `// nosemgrep` on the same line.
+    Manually commiting a transaction is highly discouraged. Read about the transaction model implemented by Frappe Framework before adding manual commits: https://frappeframework.com/docs/user/en/api/database#database-transaction-model If you think manual commit is required then add a comment explaining why and `# nosemgrep` on the same line.
   paths:
       exclude:
         - "**/patches/**"


### PR DESCRIPTION
for python file `#` would be better