### PR TITLE
fix: exclude keyword-only argument separator from type hint rule

### DIFF
--- a/rules/security/whitelisted.yml
+++ b/rules/security/whitelisted.yml
@@ -11,8 +11,8 @@ rules:
           def $FUNC(..., $ARG: $TYPE, ...): ...
       - metavariable-regex:
           metavariable: $ARG
-          # Exclude 'self' and 'cls' as they typically don't take hints
-          regex: ^(?!self$|cls$).*$
+          # Exclude 'self', 'cls', and '*' as they typically don't take hints
+          regex: ^(?!self$|cls$|\*$).*$
     message: "The argument '$ARG' in function '$FUNC' is missing a type hint."
   - id: guest-whitelisted-method
     languages: [python]


### PR DESCRIPTION
Current whitelisted functions rule expects a type hint for `*` in arguments.