### PR TITLE
fix: don't flag comprehension predicates

### DIFF
--- a/rules/code_quality.py
+++ b/rules/code_quality.py
@@ -11,3 +11,51 @@ def func(*args, **kwargs):
 # ok: overusing-args
 def func(*args):
   return 1
+
+
+import frappe
+
+doctypes = ["DocType A", "DocType B"]
+
+
+# ruleid: unchecked-frappe-permission-call
+frappe.has_permission("DocType", "read")
+
+# ok: unchecked-frappe-permission-call
+frappe.has_permission("DocType", "read", throw=True)
+
+# ok: unchecked-frappe-permission-call
+allowed = frappe.has_permission("DocType", "read")
+
+# ok: unchecked-frappe-permission-call
+if frappe.has_permission("DocType", "read"):
+  pass
+
+# ok: unchecked-frappe-permission-call
+verdict = "yes" if frappe.has_permission("DocType", "read") else "no"
+
+# ok: unchecked-frappe-permission-call
+assert frappe.has_permission("DocType", "read")
+
+
+def returns_permission():
+  # ok: unchecked-frappe-permission-call
+  return frappe.has_permission("DocType", "read")
+
+
+# value used as a comprehension predicate — not a discarded call
+
+# ok: unchecked-frappe-permission-call
+permitted_list = [d for d in doctypes if frappe.has_permission(d, "read")]
+
+# ok: unchecked-frappe-permission-call
+permitted_negated = [d for d in doctypes if not frappe.has_permission(d, "read")]
+
+# ok: unchecked-frappe-permission-call
+permitted_set = {d for d in doctypes if frappe.has_permission(d, "read")}
+
+# ok: unchecked-frappe-permission-call
+permitted_map = {d: 1 for d in doctypes if frappe.has_permission(d, "read")}
+
+# ok: unchecked-frappe-permission-call
+has_any = any(d for d in doctypes if frappe.has_permission(d, "read"))

--- a/rules/code_quality.yml
+++ b/rules/code_quality.yml
@@ -42,6 +42,11 @@ rules:
     - pattern-not-inside: "if <... frappe.has_permission(...) ...> : ..."
     - pattern-not-inside: "$PRED_TRUE if frappe.has_permission(...) else $PRED_FALSE"
     - pattern-not-inside: assert frappe.has_permission(...)
+    # value used as a comprehension predicate (list / set / dict / generator)
+    - pattern-not-inside: "[$EL for $V in $IT if <... frappe.has_permission(...) ...>]"
+    - pattern-not-inside: "{$EL for $V in $IT if <... frappe.has_permission(...) ...>}"
+    - pattern-not-inside: "{$K: $VAL for $V in $IT if <... frappe.has_permission(...) ...>}"
+    - pattern-not-inside: "($EL for $V in $IT if <... frappe.has_permission(...) ...>)"
   paths:
     exclude:
       - "**/test_*.py"


### PR DESCRIPTION
`unchecked-frappe-permission-call` flags discarded `frappe.has_permission` calls by listing the contexts where the value *is* used (assign/return/if/ternary/assert). Comprehension predicates are missing, so this false-positives:

```python
permitted = [d for d in doctypes if frappe.has_permission(d, "read")]
```

Adds `pattern-not-inside` exclusions for list/set/dict comprehensions + generators (deep-expr operator, so negated predicates count), and adds the rule's first fixtures. `make test` → 29/29 ✓.